### PR TITLE
Fix for bug where editing a comment causes it to be shared with customer

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jira - Enable Internal Comments Only
 // @namespace    http://tampermonkey.net/
-// @version      1.0.5
+// @version      1.0.6
 // @description  Prevents the "Share With Customer" button from being shown underneath the Comment box and ensures that only internal comments are available on the workflow transition screens
 // @author       Sara Milner, Matthew Lishman, Matt Anstey, Luke Rodgers, Claire Parker
 // @match        https://ampersand.atlassian.net/*
@@ -41,16 +41,36 @@ $(function() {
       // This is a fix for a strange bug in Jira. On a ticket, start on the Comments tab,
       // select the All tab. Try to edit a comment. You will now see the 'Share with Customer'
       // button! Also, cancel the overlay, only to see an identical overlay without the
-      // 'Share With Customer' button! The overlay is opening twice for some reason. This
-      // code closes the second one and uses a hacky selector to select all 'Share
+      // 'Share With Customer' button! The overlay is opening twice for some reason.
+      // This code closes all extra overlays by clicking the 'Add To Issue Only' button
+      // and uses a hacky selector to select all 'Share
       // With Customer' buttons in case there are still more than one and hide them.
       // Hacky because you can't select more than one element using an ID - IDs should
       // be unique on a page of course!
-      if($('.aui-dialog2 #button-public').length > 1) {
-          $('.aui-dialog2 #button-public')[1].click();
-          console.log("Closed buggy identical overlay");
+      var buttonPrivate = $('.aui-dialog2 #button-private');
+      var numOfExtraUnwantedOverlays = (buttonPrivate.length) - 1;
+
+
+      console.log("Number of buggy extra overlays before remove action = " + numOfExtraUnwantedOverlays);
+
+      if (numOfExtraUnwantedOverlays > 0){
+          for (var i = 1; i < buttonPrivate.length; i++) {
+              // Click the Internal Comment button (buttonPrivate) to close any extra overlays -
+              // we want to close all "extra" overlays and only leave the first overlay,
+              // i.e. buttonPrivate[0], which is why we start the 'for' loop at i = 1.
+              // Click the Internal Comment button to close the extra overlays, to ensure that
+              // the comment remains internal.
+              buttonPrivate[i].click();
+              console.log("Closed buggy extra overlay number " + i);
+          }
+
       }
+
+      // Hide the "Share With Customer" button now that we have ensured that all extra
+      // buggy overlays have been closed
+      console.log("Hiding 'Share With Customer' button...");
       $('.aui-dialog2 #button-public').hide();
+      console.log("Hidden 'Share With Customer' button");
   });
 
 });


### PR DESCRIPTION
- The bug was caused by dispatching a 'click' event on the 'Share With Customer' button to close the extra buggy overlay that opens e.g. when changing from 'Comments' tab to 'All' tab.
- Fix: Dispatch the click event on the "Add to issue only" button to close the extra overlays. This will ensure that the comment remains internal.
- Also added a check that will close all extra overlays that are opened, however many there are.
